### PR TITLE
Add form at the bottom of article

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,13 +626,16 @@
               <ul>
                 <li>What is your overall opinion about this article?</li>
                 <li>
-                  <input type="radio" name="opinion" value="positive" checked> Positive
+                  <label for=positive></label>
+                  <input type="radio" id="positive" name="opinion" value="positive" checked> Positive
                 </li>
                 <li>
-                  <input type="radio" name="opinion" value="neutral"> Neutral
+                  <label for=neutral></label>
+                  <input type="radio" id="neutral" name="opinion" value="neutral"> Neutral
                 </li>
                 <li>
-                  <input type="radio" name="opinion" value="negative"> Negative
+                  <label for=negative></label>
+                  <input type="radio" id="negative" name="opinion" value="negative"> Negative
                 </li>
               </ul>
             </li>

--- a/index.html
+++ b/index.html
@@ -203,115 +203,147 @@
           </p>
         </div>
       </div>
-        <!--Second Image-->
-        <div id="theory-image" class="theory-image">
-          <div id="theory-image-head" class="theory-image-head">
-            <h2>The Theory of Inflation</h2>
-            <p>
-              Astronomers have found evidence to support the theory of inflation,
-              which explains how the universe expanded so uniformly and so quickly
-              in the instant after the Big Bang 13.8 billion years ago.
-            </p>
-          </div>
-          <div id="inflation-image-container" class="inflation-image-container">
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/universe.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong> THE UNIVERSE </strong> is just under 14 billion years
-                      old. From our position in the Milky Way galaxy, we can observe a
-                      sphere that is now about 92 billion light-years across. But
-                      there's a mystery. Wherever we look, the universe has an even
-                      temperature.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/not-enough.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong> NOT ENOUGH TIME </strong> The universe is not old
-                      enough for light to have traveled the vast distance from one
-                      side of the universe to the other, and there has not been enough
-                      time for scattered patches of hot and cold to mix into an even
-                      temperature.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/distant-coffee.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong> DISTANT COFFEE </strong> At a smaller scale, imagine
-                      using a telescope to look a mile in one direction. You see a
-                      coffee cup, and from the amount of steam, you can estimate its
-                      temperature and how much it has cooled.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/coffee-everywhere.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong>COFFEE EVERYWHERE</strong> Now turn around and look a
-                      mile in the other direction. You see a similar coffee cup, at
-                      exactly the same temperature. Coincidence? Maybe. But if you see
-                      a similar cup in every direction, you might want to look for
-                      another explanation.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/still-not.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong>STILL NOT ENOUGH TIME</strong> There has not been enough
-                      time to carry coffee cups from place to place before they get
-                      cold. But if all the coffee cups were somehow filled from a
-                      single coffee pot, all at the same time, that might explain
-                      their even temperature
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/inflation.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong>INFLATION</strong> solves this problem. The theory
-                      proposes that, less than a trillionth of a second after the Big
-                      Bang, the universe expanded faster than the speed of light. Tiny
-                      ripples in the violently expanding energy field eventually grew
-                      into the large-scale structures of the universe.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/fluctuation.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong>FLUCTUATION</strong> Astronomers have now detected
-                      evidence of these ancient fluctuations in swirls of polarized
-                      light in the cosmic background radiation, which is energy left
-                      over from the early universe. These are gravitational waves
-                      predicted by Einstein.
-                    </p>
-                  </div>
-              </div>
-              <div class="explanation-cell">
-                  <img class="inflation-image" src="./inflation-img/expansion.png" alt="">
-                  <div class="explanation">
-                    <p>
-                      <strong>EXPANSION</strong> Returning to our coffee, imagine a
-                      single, central pot expanding faster than light and cooling to
-                      an even temperature as it expands. That is something like
-                      inflation. And the structure of the universe mirrors the froth
-                      and foam of the original pot.
-                    </p>
-                  </div>
-              </div>
-            </div>
-          <p id="theory-image-authors">By LARRY BUCHANAN and JONATHAN CORUM</p>
+      <!--Second Image-->
+      <div id="theory-image" class="theory-image">
+        <div id="theory-image-head" class="theory-image-head">
+          <h2>The Theory of Inflation</h2>
+          <p>
+            Astronomers have found evidence to support the theory of inflation,
+            which explains how the universe expanded so uniformly and so quickly
+            in the instant after the Big Bang 13.8 billion years ago.
+          </p>
         </div>
+        <div id="inflation-image-container" class="inflation-image-container">
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/universe.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong> THE UNIVERSE </strong> is just under 14 billion years
+                old. From our position in the Milky Way galaxy, we can observe a
+                sphere that is now about 92 billion light-years across. But
+                there's a mystery. Wherever we look, the universe has an even
+                temperature.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/not-enough.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong> NOT ENOUGH TIME </strong> The universe is not old
+                enough for light to have traveled the vast distance from one
+                side of the universe to the other, and there has not been enough
+                time for scattered patches of hot and cold to mix into an even
+                temperature.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/distant-coffee.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong> DISTANT COFFEE </strong> At a smaller scale, imagine
+                using a telescope to look a mile in one direction. You see a
+                coffee cup, and from the amount of steam, you can estimate its
+                temperature and how much it has cooled.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/coffee-everywhere.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong>COFFEE EVERYWHERE</strong> Now turn around and look a
+                mile in the other direction. You see a similar coffee cup, at
+                exactly the same temperature. Coincidence? Maybe. But if you see
+                a similar cup in every direction, you might want to look for
+                another explanation.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/still-not.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong>STILL NOT ENOUGH TIME</strong> There has not been enough
+                time to carry coffee cups from place to place before they get
+                cold. But if all the coffee cups were somehow filled from a
+                single coffee pot, all at the same time, that might explain
+                their even temperature
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/inflation.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong>INFLATION</strong> solves this problem. The theory
+                proposes that, less than a trillionth of a second after the Big
+                Bang, the universe expanded faster than the speed of light. Tiny
+                ripples in the violently expanding energy field eventually grew
+                into the large-scale structures of the universe.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/fluctuation.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong>FLUCTUATION</strong> Astronomers have now detected
+                evidence of these ancient fluctuations in swirls of polarized
+                light in the cosmic background radiation, which is energy left
+                over from the early universe. These are gravitational waves
+                predicted by Einstein.
+              </p>
+            </div>
+          </div>
+          <div class="explanation-cell">
+            <img
+              class="inflation-image"
+              src="./inflation-img/expansion.png"
+              alt=""
+            />
+            <div class="explanation">
+              <p>
+                <strong>EXPANSION</strong> Returning to our coffee, imagine a
+                single, central pot expanding faster than light and cooling to
+                an even temperature as it expands. That is something like
+                inflation. And the structure of the universe mirrors the froth
+                and foam of the original pot.
+              </p>
+            </div>
+          </div>
+        </div>
+        <p id="theory-image-authors">By LARRY BUCHANAN and JONATHAN CORUM</p>
+      </div>
       <!--Second Section-->
       <div class="container">
         <p>
@@ -572,6 +604,49 @@
           </li>
         </ul>
       </div>
+      <!-- Comment form -->
+      <div class="comment-form">
+        <h4>Help us with your feedback!</h4>
+        <form action="#" method="post">
+          <ul>
+            <li>
+              <label class="text-label" for="name">Name*: </label>
+              <input type="text" id="name" name="name" class="text-fields" required maxlength="20">
+            </li>
+            <li>
+              <label class="text-label" for="email">E-mail*: </label>
+              <input type="email" id="email" name="email" class="text-fields" required maxlength="20">
+            </li>
+            <li>
+              <label class="text-label" for="comment">Comment*: </label>
+              <textarea id="comment" name="comment" required maxlength="250" class="text-fields" placeholder="Leave you comment here..."></textarea>
+            </li>
+            <li><small>* Required fields</small></li>
+            <li>
+              <ul>
+                <li>What is your overall opinion about this article?</li>
+                <li>
+                  <input type="radio" name="opinion" value="positive" checked> Positive
+                </li>
+                <li>
+                  <input type="radio" name="opinion" value="neutral"> Neutral
+                </li>
+                <li>
+                  <input type="radio" name="opinion" value="negative"> Negative
+                </li>
+              </ul>
+            </li>
+            <li>
+              <label for="subscribe"></label>
+              <input type="checkbox" id="subscribe" name="subscribe" value="subscribed" checked> I want to subscribe to the newsletter
+            </li>
+            <li>
+              <label for="submit"></label>
+              <input class="btn send-btn" type="submit" id="submit" value="Send">
+            </li>
+          </ul>
+        </form>
+      </div>
       <!--Bottom Section-->
       <div id="bottom-panel">
         <!--Section of the bottom Panel-->
@@ -781,7 +856,7 @@
         <!--Aside-->
         <aside>
           <h4>Most Popular</h4>
-          <ul id="link-list">
+          <ul class="link-list">
             <li>
               <a class="popular-link" href="#"
                 >The Brilliant, Bitter, Unlikable Scion of an American Political

--- a/style.css
+++ b/style.css
@@ -384,7 +384,7 @@ aside {
   margin-left: 30px;
 }
 
-#link-list li {
+.link-list li {
   border-top: 1px solid rgb(226, 226, 226);
   padding: 15px 0;
 }
@@ -542,4 +542,35 @@ aside {
 
 .popular-link:hover {
   color: rgb(102, 102, 102);
+}
+
+/* form */
+
+form {
+  margin: 1.5rem auto;
+}
+
+.comment-form {
+  width: 600px;
+  margin: 0 auto;
+  font-family: Helvetica, Arial, sans-serif;
+  text-align: left;
+}
+
+.comment-form li {
+  margin: 5px 0;
+  font-size: 15px;
+}
+
+.text-label {
+  display: inline-block;
+  width: 100px;
+}
+
+.text-fields {
+  width: 80%;
+}
+
+.send-btn {
+  width: 150px;
 }


### PR DESCRIPTION
The "Help us with your feedback" form was placed at the bottom of the article, as a way to approach users that scrolled down to the end of it, and hence might be interested in giving some feedback to the site.
No pop-ups neither collapsable features were used as a way to be consistent with the minimalistic layout of the page.
Build-up client-side form validation was implemented in the text fields, as well as labels and placeholders for accessibility purposes.